### PR TITLE
Update Swagger API documentation handling and add NODE_ENV variable

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,7 @@ JWT_SECRET=your_jwt_secret  # Secret key for JWT token signing
 
 # Frontend URL
 FRONTEND_URL=http://localhost:5173  # URL of the frontend application
+NODE_ENV= #production or development
 
 # LDAP Configuration
 LDAP_ADMIN_DN=cn=admin,dc=example,dc=com  # Distinguished Name for LDAP admin

--- a/backend/index.js
+++ b/backend/index.js
@@ -47,6 +47,9 @@ app.set("views", path.join(__dirname, "views"));
 // Set the port from environment variable or default to 85
 const PORT = process.env.PORT || 85;
 
+const isProduction = process.env.NODE_ENV === 'production' || (process.env.FRONTEND_URL && process.env.FRONTEND_URL.includes('canaryweather.xyz'));
+const isDevelopment = !isProduction;
+
 // Define allowed origins for CORS (Cross-Origin Resource Sharing)
 // This list should match the one used in the WebSocket service.
 const ALLOWED_ORIGINS = [
@@ -93,8 +96,6 @@ app.use(
 app.use("/uploads", express.static(path.join(__dirname, "uploads")));
 
 // Swagger API Documentation - Route based on environment
-const isDevelopment = process.env.NODE_ENV !== 'production';
-
 app.use(
   "/api-docs",
   isDevelopment 

--- a/frontend/src/pages/AboutUs.jsx
+++ b/frontend/src/pages/AboutUs.jsx
@@ -371,7 +371,6 @@ const ContactSection = ({ t }) => {
                             </div>
                         </form>
                     </div>
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Enhance the handling of Swagger API documentation based on the environment and introduce the NODE_ENV variable in the example environment file. Update environment checks in the application to differentiate between production and development modes.