### PR TITLE
Update Swagger API documentation route and add redirect component

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -98,7 +98,7 @@ app.use("/uploads", express.static(path.join(__dirname, "uploads")));
 // Swagger API Documentation
 app.use(
   "/api/docs",
-  swaggerUi.serveFiles(swaggerSpec, {}),
+  swaggerUi.serve,
   swaggerUi.setup(swaggerSpec, {
     customCss: ".swagger-ui .topbar { display: none }",
     customSiteTitle: "CanaryWeather API Docs",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import i18n from '../i18n/index.js';
 import { ThemeProvider } from './context/ThemeContext';
 import { restoreSession } from './services/userService';
 import ScrollToTop from './components/ScrollToTop';
+import RedirectToApiDocs from './components/RedirectToApiDocs';
 
 // Lazy load pages for better performance
 const Home = lazy(() => import('./pages/Home'));
@@ -92,6 +93,7 @@ function App() {
                     <ScrollToTop />
                     <Suspense fallback={<PageLoader />}>
                         <Routes>
+                            <Route path="/api-docs" element={<RedirectToApiDocs />} />
                             <Route element={<Layout />}>
                                 <Route path="/" element={<Home />} />
                                 <Route path="/pois" element={<PointsOfInterest />} />

--- a/frontend/src/components/RedirectToApiDocs.jsx
+++ b/frontend/src/components/RedirectToApiDocs.jsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+
+const RedirectToApiDocs = () => {
+  useEffect(() => {
+    window.location.href = '/api/docs';
+  }, []);
+
+  return null;
+};
+
+export default RedirectToApiDocs;


### PR DESCRIPTION
Update the route for Swagger API documentation and implement a redirect component to streamline access to the documentation.